### PR TITLE
Downgrade app compact lib version to 1.1.0

### DIFF
--- a/social-connect/build.gradle
+++ b/social-connect/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 
     implementation 'androidx.navigation:navigation-fragment:2.3.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'


### PR DESCRIPTION
## Overview :notebook:
We found during the latest release that the new app compact version (which this library used) introduces some breaking changes regarding locale configuration that deprecated `AppCompatDelegate.attachBaseContext()`. As a temporary fix, this PR matches the app compact version to the one that we use in our app: `1.1.0`
